### PR TITLE
0.4.0: Adjust brand marker to branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ All dependencies are specified in `requirements.txt` for easy installation.
 ```
 
 ## CHANGELOG
+`0.4.0` - 2025-08-23
+- Created custom point marker based on branding.
 `0.3.1` - 2025-08-23
 - Fixed bug that ignored user filename input.
 `0.3.0` - 2025-08-23

--- a/map_point_parser.py
+++ b/map_point_parser.py
@@ -61,12 +61,24 @@ def add_existing_points_to_map(map_object):
     None
         Adds markers for all existing points to the map.
     """
+    custom_icon = folium.DivIcon(
+        html=f"""
+        <div style="
+            background-color:#f75f61;
+            width:16px;
+            height:16px;
+            border-radius:50%;
+            border:2px solid white;">
+        </div>
+        """
+    )
     for point_index, point in enumerate(st.session_state.points):
         coords = point["geometry"]["coordinates"]
 
         folium.Marker(
             location=[coords[1], coords[0]],  # Note: folium uses [lat, lon]
             tooltip=f"Point {point_index + 1}: {point['properties']['name']}",
+            icon=custom_icon,
         ).add_to(map_object)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "click2vector"
-version = "0.3.1"
+version = "0.4.0"
 description = "Interactive map application for creating and exporting GeoJSON points"
 authors = [{name = "Chiara Phillips", email = "contact@chiaraphillips.com"}]
 readme = "README.md"


### PR DESCRIPTION
Based on inspiration from: 
https://python-graph-gallery.com/312-add-markers-on-folium-map/
https://stackoverflow.com/questions/75421574/how-to-customize-marker-styles-and-add-numbers-inside-folium-markers

This PR changes the point marker from the default blue leaflet/folium style to the same style (#f75f61) as the rest of the app for consistent branding. 