### PR TITLE
0.5.0: Add multiple basemap options

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,15 +97,23 @@ All dependencies are specified in `requirements.txt` for easy installation.
 ```
 
 ## CHANGELOG
-`0.4.0` - 2025-08-23
+
+`0.5.0` : 2025-08-23
+- Added ability for the user to select different basemap options (CartoDB Positron, OpenStreetMap, Esri World Imagery)
+
+`0.4.0` : 2025-08-23
 - Created custom point marker based on branding.
-`0.3.1` - 2025-08-23
+
+`0.3.1` : 2025-08-23
 - Fixed bug that ignored user filename input.
-`0.3.0` - 2025-08-23
+
+`0.3.0` : 2025-08-23
 - Adjusted basemap tiles from `OpenStreetMap` to `Cartodb Positron`
-`0.2.0` - 2025-08-23
+
+`0.2.0` : 2025-08-23
 - Added radio button for specifying which coordinate type to import from Google Sheets.
-`0.1.0` - 2025-07-16
+
+`0.1.0` : 2025-07-16
 - Initial release
 
 

--- a/map_point_parser.py
+++ b/map_point_parser.py
@@ -6,8 +6,13 @@ from streamlit_folium import st_folium
 from click_to_geojson_functionality import add_point
 
 
-def create_map_with_features():
+def create_map_with_features(basemap_name):
     """Create a folium map with search and mini-map features.
+
+    Parameters
+    ----------
+    basemap_name : str
+        The name of the basemap to use.
 
     Returns
     -------
@@ -20,7 +25,7 @@ def create_map_with_features():
     map_object = folium.Map(
         location=last_view["center"],
         zoom_start=last_view["zoom"],
-        tiles="Cartodb Positron",
+        tiles=basemap_name,
     )
 
     # Add search functionality (pan only, no markers)
@@ -35,7 +40,7 @@ def create_map_with_features():
 
     # Add an inset map (mini map)
     mini_map = folium.plugins.MiniMap(
-        tile_layer="Cartodb Positron",
+        tile_layer=basemap_name,
         position="bottomright",
         width=150,
         height=150,
@@ -225,8 +230,13 @@ def create_point_table():
             pass
 
 
-def render_map_interface():
+def render_map_interface(basemap_name):
     """Main function to render the complete map interface.
+
+    Parameters
+    ----------
+    basemap_name : str
+        The name of the basemap to use.
 
     Returns
     -------
@@ -234,7 +244,7 @@ def render_map_interface():
         The map data returned from st_folium for further processing.
     """
     # Create map with features
-    map_object = create_map_with_features()
+    map_object = create_map_with_features(basemap_name)
 
     # Add existing points to map
     add_existing_points_to_map(map_object)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "click2vector"
-version = "0.4.0"
+version = "0.5.0"
 description = "Interactive map application for creating and exporting GeoJSON points"
 authors = [{name = "Chiara Phillips", email = "contact@chiaraphillips.com"}]
 readme = "README.md"

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -60,8 +60,15 @@ if sheets_url and sheets_url != st.session_state.get("last_sheets_url", ""):
     if success:
         st.rerun()
 
+basemap_name = st.radio(
+    "Basemap options:",
+    options=["CartoDB Positron", "OpenStreetMap", "Esri World Imagery"],
+    index=0,
+    horizontal=True,
+)
+
 # Render the map interface using the new module
-render_map_interface()
+render_map_interface(basemap_name)
 
 
 # Only show export options if points exist


### PR DESCRIPTION
In this PR, I add the ability for the user to choose what [basemap](https://leaflet-extras.github.io/leaflet-providers/preview/) they'd like for the app. As a default, it uses CartoDB Positron.