### PR TITLE
0.7.0: Add GeoJSON pretty print export

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ All dependencies are specified in `requirements.txt` for easy installation.
 ```
 
 ## CHANGELOG
+`0.7.0` : 2025-08-24
+- Added GeoJSON pretty print format with GeoJSON export option.
+
 `0.6.0` : 2025-08-23
 - Added columns to input and output UI to shorten scroll space in the app.
 

--- a/click_to_geojson_functionality.py
+++ b/click_to_geojson_functionality.py
@@ -243,6 +243,20 @@ def _export_flatgeobuf():
         return b""
 
 
+def _export_geojson_display():
+    """Export data as GeoJSON in pretty-printed format for display.
+
+    Returns
+    -------
+    str
+        The GeoJSON data as a formatted string ready for display.
+    """
+    # Create the GeoJSON with pretty formatting for display
+    geojson_data = create_geojson()
+    # Use pretty formatting for easy reading
+    return json.dumps(geojson_data, indent=2)
+
+
 def export_data(gdf, export_type):
     """Export GeoDataFrame to the specified format.
 
@@ -260,7 +274,7 @@ def export_data(gdf, export_type):
     """
     # Use a mapping instead of if/elif chains
     export_functions = {
-        "GeoJSON": lambda: json.dumps(create_geojson(), indent=2),
+        "GeoJSON": _export_geojson_display,
         "Esri Shapefile (.zip)": _export_shapefile,
         "FlatGeobuf": _export_flatgeobuf,
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "click2vector"
-version = "0.6.0"
+version = "0.7.0"
 description = "Interactive map application for creating and exporting GeoJSON points"
 authors = [{name = "Chiara Phillips", email = "contact@chiaraphillips.com"}]
 readme = "README.md"

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -74,25 +74,24 @@ render_map_interface(basemap_name)
 # Only show export options if points exist
 if st.session_state.points:
     # Export file type selection
-    col1, col2 = st.columns([1.5, 1])
-    with col1:
-        export_type = st.radio(
-            "Export file type:",
-            options=["GeoJSON", "Esri Shapefile (.zip)", "FlatGeobuf"],
-            index=0,
-            horizontal=True,
-            key="export_type_radio",
-        )
+    export_type = st.radio(
+        "Export file type:",
+        options=["GeoJSON", "Esri Shapefile (.zip)", "FlatGeobuf"],
+        index=0,
+        horizontal=True,
+        key="export_type_radio",
+    )
+
     # Custom filename input - store in session state to persist across reruns
     if "custom_filename" not in st.session_state:
         st.session_state.custom_filename = get_base_filename()
-    with col2:
-        custom_filename = st.text_input(
-            "Export file name:",
-            value=st.session_state.custom_filename,
-            placeholder="Enter export file name",
-            key="filename_input",
-        )
+
+    custom_filename = st.text_input(
+        "Export file name:",
+        value=st.session_state.custom_filename,
+        placeholder="Enter export file name",
+        key="filename_input",
+    )
 
     # Update session state with the current input value
     st.session_state.custom_filename = custom_filename
@@ -108,12 +107,14 @@ if st.session_state.points:
 
     export_filename = {
         "GeoJSON": f"{filename}.geojson",
+        "GeoJSON.io": f"{filename}.geojson",
         "Esri Shapefile (.zip)": f"{filename}.zip",
         "FlatGeobuf": f"{filename}.fgb",
     }[export_type]
 
     export_mime = {
         "GeoJSON": "application/geo+json",
+        "GeoJSON.io": "text/plain",
         "Esri Shapefile (.zip)": "application/zip",
         "FlatGeobuf": "application/octet-stream",
     }[export_type]
@@ -132,6 +133,7 @@ if st.session_state.points:
     # Show download button
     col1, col2, col3 = st.columns([2, 2, 1])
     with col2:
+        # Single download button for all formats
         st.download_button(
             label="Download Vector",
             data=export_data(gdf, export_type),
@@ -139,3 +141,7 @@ if st.session_state.points:
             mime=export_mime,
             type="primary",
         )
+    # Show GeoJSON code block if that format is selected
+    if export_type == "GeoJSON":
+        geojson_data = export_data(gdf, export_type)
+        st.code(geojson_data, language="json")


### PR DESCRIPTION
In this PR, I add pretty print GeoJSON to the GeoJSON export option. This makes it easier to copy the point data for use in MapLibre.