### PR TITLE
Infer export file type in export name

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ multiple vector formats. Click on a map, import from Google Sheets, or enter coo
  manually to build your dataset, then export it for use in GIS software, web maps, or
  other spatial applications.
 
-[![Open in Streamlit](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://click2vector.streamlit.app/)
+[Open in Streamlit](https://click2vector.streamlit.app/)
 
 ## Installation & Setup
 
@@ -81,10 +81,14 @@ Your Google Sheet should have either:
 - **Advanced Options**: Basemap, default pin color, inset map toggle, Google Sheets
   import, export format, and GeoJSON preview
 - **Export Data**: Choose GeoJSON, Esri Shapefile (.zip), or FlatGeobuf and download
-  your dataset
+  your dataset; exports include `lat` and `lon` attribute columns
 
 
 ## CHANGELOG
+`0.9.1` : 2026-05-30
+- Added `lat` and `lon` attribute columns to all export formats.
+- Added export filename extension inference from the selected format.
+
 `0.9.0` : 2026-05-30
 - Added optional description column per point, included in exports.
 - Added pin colors by description with per-value color pickers in the Point Table.

--- a/click_to_geojson_functionality.py
+++ b/click_to_geojson_functionality.py
@@ -84,12 +84,12 @@ def reset_points():
     st.session_state.last_click = None
 
 
-def points_to_gdf(points):
+def points_to_gdf(points: list[dict]) -> gpd.GeoDataFrame:
     """Convert session points (GeoJSON features) to a GeoDataFrame.
 
     Parameters
     ----------
-    points : list
+    points : list of dict
         List of GeoJSON feature dictionaries.
 
     Returns
@@ -106,7 +106,12 @@ def points_to_gdf(points):
     for pt in points:
         lon, lat = pt["geometry"]["coordinates"]
         geometries.append(Point(lon, lat))
-        properties_list.append(pt["properties"].copy())
+        properties = {
+            key: value
+            for key, value in pt["properties"].items()
+            if key not in ("lat", "lon")
+        }
+        properties_list.append({"lat": lat, "lon": lon, **properties})
 
     gdf = gpd.GeoDataFrame(properties_list, geometry=geometries, crs="EPSG:4326")
 
@@ -122,6 +127,39 @@ def get_base_filename():
         A filename with format 'click2vector_YYYYMMDD_HHMMSS'.
     """
     return f"click2vector_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+
+
+EXPORT_EXTENSIONS: dict[str, str] = {
+    "GeoJSON": ".geojson",
+    "GeoJSON.io": ".geojson",
+    "Esri Shapefile (.zip)": ".zip",
+    "FlatGeobuf": ".fgb",
+}
+
+_KNOWN_EXPORT_SUFFIXES = frozenset({".geojson", ".json", ".zip", ".fgb"})
+
+
+def build_export_filename(filename: str, export_type: str) -> str:
+    """Return a download filename with the extension for ``export_type``.
+
+    Parameters
+    ----------
+    filename : str
+        User-provided filename, with or without an extension.
+    export_type : str
+        Selected export format key.
+
+    Returns
+    -------
+    str
+        Filename including the appropriate extension.
+    """
+    stem = filename.strip() or get_base_filename()
+    path = Path(stem)
+    if path.suffix.lower() in _KNOWN_EXPORT_SUFFIXES:
+        stem = path.stem
+
+    return f"{stem}{EXPORT_EXTENSIONS[export_type]}"
 
 
 def _export_shapefile(gdf: gpd.GeoDataFrame) -> bytes:
@@ -179,17 +217,20 @@ def _export_flatgeobuf(gdf: gpd.GeoDataFrame) -> bytes:
         return b""
 
 
-def _export_geojson_display():
+def _export_geojson_display(gdf: gpd.GeoDataFrame) -> str:
     """Export data as GeoJSON in pretty-printed format for display.
+
+    Parameters
+    ----------
+    gdf : geopandas.GeoDataFrame
+        The GeoDataFrame to export.
 
     Returns
     -------
     str
         The GeoJSON data as a formatted string ready for display.
     """
-    # Create the GeoJSON with pretty formatting for display
-    geojson_data = create_geojson()
-    # Use pretty formatting for easy reading
+    geojson_data = json.loads(gdf.to_json())
     return json.dumps(geojson_data, indent=2)
 
 
@@ -210,7 +251,7 @@ def export_data(gdf, export_type):
     """
     # Use a mapping instead of if/elif chains
     export_functions = {
-        "GeoJSON": lambda _: _export_geojson_display(),
+        "GeoJSON": _export_geojson_display,
         "Esri Shapefile (.zip)": _export_shapefile,
         "FlatGeobuf": _export_flatgeobuf,
     }

--- a/map_point_parser.py
+++ b/map_point_parser.py
@@ -12,7 +12,7 @@ from click_to_geojson_functionality import add_point
 from styling import DEFAULT_BUTTON_COLOR
 
 NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
-USER_AGENT = "click2vector/0.9.0"
+USER_AGENT = "click2vector/0.9.1"
 DESCRIPTION_COLOR_PALETTE = [
     "#4363d8",
     "#3cb44b",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "click2vector"
-version = "0.9.0"
+version = "0.9.1"
 description = "Interactive map application for creating and exporting GeoJSON points"
 authors = ["Chiara Phillips <contact@chiaraphillips.com>"]
 readme = "README.md"

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -5,6 +5,7 @@ This is the main Streamlit app that combines all the functionality.
 import streamlit as st
 
 from click_to_geojson_functionality import (
+    build_export_filename,
     export_data,
     get_base_filename,
     points_to_gdf,
@@ -154,12 +155,7 @@ if st.session_state.points:
 
     gdf = points_to_gdf(st.session_state.points)
 
-    export_filename = {
-        "GeoJSON": f"{filename}.geojson",
-        "GeoJSON.io": f"{filename}.geojson",
-        "Esri Shapefile (.zip)": f"{filename}.zip",
-        "FlatGeobuf": f"{filename}.fgb",
-    }[export_type]
+    export_filename = build_export_filename(filename, export_type)
 
     export_mime = {
         "GeoJSON": "application/geo+json",


### PR DESCRIPTION
Release **v0.9.1** with two export improvements:

- **`lat` and `lon` attribute columns** are included in GeoJSON, Shapefile, and FlatGeobuf exports, derived from each point’s geometry (so dragged pins stay in sync)
- **Export filenames** get the correct extension from the selected format (`.geojson`, `.zip`, `.fgb`) when omitted, and swap cleanly when the format changes