### PR TITLE
Introduce compact expanders

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,28 +60,30 @@ For development, install additional dependencies and set up pre-commit hooks:
 ### Adding Points
 - **Map Clicking**: Click anywhere on the map to drop a pin; drag pins to adjust
   their location
-- **Place Search**: Search for a place above the map and click **Add pin** to
-  geocode it
+- **Place Search**: Search for a place above the map and press Enter to geocode it
+  as a pin
 - **Google Sheets Import**: Paste a public Google Sheets URL with coordinate data
   (under Advanced options)
 
 ### Google Sheets Import
-Your Google Sheet should have either:
-- A column with 'wkt' or 'geom' in the name containing WKT Point format: `Point (longitude latitude)`
-- OR separate columns with 'lat' and 'lon' (or 'lng') in their names
+Paste a public Google Sheet URL with `lat` and `lon` columns under Advanced
+options (or choose WKT Geometry below the URL). Include `#gid=...` in the URL when
+your data is on another tab. If headers are missing, the app shows an error with
+guidance on title rows and header placement.
 
 ### Managing Your Data
 - **View Points**: Expand the "Point Table" to see all points in an editable table
 - **Descriptions**: Add an optional description per point; descriptions are included
   in exports
-- **Pin Colors**: Map pins are colored by description; set a color for each unique
-  description in the Point Table
-- **Delete Points**: Select rows in the table to remove points, or use **Remove Last
-  Point** and **Clear All Points**
-- **Advanced Options**: Basemap, default pin color, inset map toggle, Google Sheets
-  import, export format, and GeoJSON preview
-- **Export Data**: Choose GeoJSON, Esri Shapefile (.zip), or FlatGeobuf and download
-  your dataset; exports include `lat` and `lon` attribute columns
+- **Pin Colors**: Choose a column to color pins by (default: Description); each
+  category is read-only, with an editable legend label and color picker
+- **Map Options**: Fullscreen expand button on the map; basemap, inset map, and
+  Google Sheets import are under Advanced options below place search
+- **Legend**: Optional category color legend on the map (toggle below pin colors)
+- **Delete Points**: Delete rows directly in the Point Table using the row delete
+  control
+- **Export Data**: Choose export format and filename, then download; exports include
+  `lat` and `lon` attribute columns
 
 
 ## CHANGELOG

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ guidance on title rows and header placement.
 - Reorganized search, Advanced options, Point Table, and export layout.
 - Added direct row deletion in the Point Table and Enter-to-search for place lookup.
 - Removed separate point-management buttons and custom global button styling.
+- Added more basemap options
 
 `0.9.1` : 2026-05-30
 - Added `lat` and `lon` attribute columns to all export formats.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ guidance on title rows and header placement.
 
 
 ## CHANGELOG
+`0.10.0` : 2026-05-30
+- Added Google Sheets tab selection from `#gid=...` in the shared URL.
+- Added informative import errors when coordinate headers are missing or below a
+  title row.
+- Added pin coloring by any Point Table column, with editable legend display names.
+- Added optional category color legend on the map and Folium fullscreen control.
+- Reorganized search, Advanced options, Point Table, and export layout.
+- Added direct row deletion in the Point Table and Enter-to-search for place lookup.
+- Removed separate point-management buttons and custom global button styling.
+
 `0.9.1` : 2026-05-30
 - Added `lat` and `lon` attribute columns to all export formats.
 - Added export filename extension inference from the selected format.

--- a/google_sheets_parser.py
+++ b/google_sheets_parser.py
@@ -2,6 +2,8 @@
 This module contains the functionality for importing data from Google Sheets.
 """
 
+from urllib.parse import parse_qs, urlparse
+
 import pandas as pd
 import streamlit as st
 
@@ -39,29 +41,57 @@ def extract_sheet_id(sheets_url):
         raise ValueError(f"Invalid Google Sheets URL: {e}")
 
 
-def get_csv_url(sheet_id):
+def extract_sheet_gid(sheets_url: str) -> str:
+    """Extract tab gid from a Google Sheets URL.
+
+    Parameters
+    ----------
+    sheets_url : str
+        The Google Sheets URL, optionally including ``#gid=...`` or ``?gid=...``.
+
+    Returns
+    -------
+    str
+        The tab gid from the URL, or ``"0"`` for the first tab when not specified.
+    """
+    parsed = urlparse(sheets_url)
+    if parsed.fragment.startswith("gid="):
+        return parsed.fragment.split("=", 1)[1].split("&")[0]
+    query_gid = parse_qs(parsed.query).get("gid")
+    if query_gid:
+        return query_gid[0]
+    return "0"
+
+
+def get_csv_url(sheet_id: str, gid: str = "0") -> str:
     """Generate CSV export URL for Google Sheets.
 
     Parameters
     ----------
     sheet_id : str
         The Google Sheets ID.
+    gid : str
+        The tab gid to export. Defaults to the first tab.
 
     Returns
     -------
     str
         The CSV export URL for the sheet.
     """
-    return f"https://docs.google.com/spreadsheets/d/{sheet_id}/export?format=csv&gid=0"
+    return (
+        f"https://docs.google.com/spreadsheets/d/{sheet_id}/export?format=csv&gid={gid}"
+    )
 
 
-def load_sheet_data(csv_url):
+def load_sheet_data(csv_url, header=0):
     """Load data from Google Sheets CSV URL.
 
     Parameters
     ----------
     csv_url : str
         The CSV export URL for the Google Sheet.
+    header : int
+        Row number to use as the column header row.
 
     Returns
     -------
@@ -74,12 +104,94 @@ def load_sheet_data(csv_url):
         If the sheet cannot be accessed or loaded.
     """
     try:
-        df = pd.read_csv(csv_url)
+        df = pd.read_csv(csv_url, header=header)
         if df.empty:
             raise ValueError("Google Sheet is empty")
-        return df
+        return df.dropna(how="all")
     except Exception as e:
         raise Exception(f"Could not access Google Sheet: {e}")
+
+
+def detect_likely_header_row(csv_url: str, use_wkt: bool, max_scan: int = 5) -> int | None:
+    """Detect whether coordinate headers appear below row 1.
+
+    Parameters
+    ----------
+    csv_url : str
+        The CSV export URL for the Google Sheet.
+    use_wkt : bool
+        If True, search for a WKT geometry column. If False, search for lat/lon.
+    max_scan : int
+        Maximum number of header rows below row 1 to inspect.
+
+    Returns
+    -------
+    int or None
+        The 1-based sheet row number where headers likely start, or ``None``.
+    """
+    for header_index in range(1, max_scan):
+        try:
+            df = load_sheet_data(csv_url, header=header_index)
+        except Exception:
+            continue
+        wkt_col, lat_col, lon_col = find_coordinate_columns(df, use_wkt)
+        if use_wkt and wkt_col:
+            return header_index + 1
+        if not use_wkt and lat_col and lon_col:
+            return header_index + 1
+    return None
+
+
+def build_missing_column_error(
+    df: pd.DataFrame, use_wkt: bool, likely_header_row: int | None
+) -> str:
+    """Build an informative error when coordinate columns are missing.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        The DataFrame loaded using row 1 as headers.
+    use_wkt : bool
+        If True, the import expected a WKT geometry column.
+    likely_header_row : int or None
+        Detected 1-based row number where headers may actually start.
+
+    Returns
+    -------
+    str
+        User-facing error message.
+    """
+    columns_text = ", ".join(str(col) for col in df.columns)
+    if likely_header_row is not None:
+        expected = (
+            "a `wkt` or `geom` column"
+            if use_wkt
+            else "`lat` and `lon` (or `lng`) columns"
+        )
+        return (
+            f"**Column headers were not found on row 1.** Available columns: "
+            f"{columns_text}. Expected {expected} appear to start on row "
+            f"{likely_header_row}. Remove title rows above your headers, or move "
+            f"the header row to row 1."
+        )
+    if len(df.columns) == 1:
+        expected = (
+            "a WKT geometry column"
+            if use_wkt
+            else "`lat` and `lon` columns"
+        )
+        return (
+            f"**No coordinate columns found on row 1.** The sheet only has one "
+            f"column: {columns_text}. This often means a title row is above your "
+            f"headers. Put {expected} on row 1."
+        )
+    expected = "`wkt` or `geom`" if use_wkt else "`lat` and `lon` or `lng`"
+    return (
+        f"**No {'WKT geometry' if use_wkt else 'lat/lon'} columns found.** "
+        f"Available columns: {columns_text}. Looking for columns containing "
+        f"{expected}. Check the tab URL includes `#gid=...` if your data is on "
+        f"another tab, and ensure column headers are on row 1."
+    )
 
 
 def find_coordinate_columns(df, use_wkt=True):
@@ -258,11 +370,9 @@ def import_from_google_sheets(sheets_url, use_wkt=True):
         try:
             # Extract sheet ID and load data
             sheet_id = extract_sheet_id(sheets_url)
-            csv_url = get_csv_url(sheet_id)
+            gid = extract_sheet_gid(sheets_url)
+            csv_url = get_csv_url(sheet_id, gid)
             df = load_sheet_data(csv_url)
-
-            # Remove completely empty rows
-            df = df.dropna(how="all")
 
             # Find coordinate columns
             wkt_col, lat_col, lon_col = find_coordinate_columns(df, use_wkt)
@@ -270,23 +380,21 @@ def import_from_google_sheets(sheets_url, use_wkt=True):
             # Validate we have the expected coordinate columns
             if use_wkt:
                 if not wkt_col:
+                    likely_header_row = detect_likely_header_row(
+                        csv_url, use_wkt=True
+                    )
                     st.error(
-                        f"**No WKT geometry column found.** Available columns: "
-                        f"{', '.join(df.columns)}. Looking for columns containing "
-                        "'wkt' or 'geom'. "
-                        "Please ensure your sheet has a WKT geometry column "
-                        "or use lat/lon columns instead."
+                        build_missing_column_error(df, True, likely_header_row)
                     )
                     return False
                 st.success(f"Found WKT column: {wkt_col}")
             else:
                 if not lat_col or not lon_col:
+                    likely_header_row = detect_likely_header_row(
+                        csv_url, use_wkt=False
+                    )
                     st.error(
-                        f"**No lat/lon columns found.** Available columns: "
-                        f"{', '.join(df.columns)}. Looking for columns containing "
-                        "'lat' and 'lon' or 'lng'. "
-                        "Please ensure your sheet has latitude "
-                        "and longitude columns or use WKT geometry instead."
+                        build_missing_column_error(df, False, likely_header_row)
                     )
                     return False
                 st.success(f"Found coordinate columns: {lat_col} and {lon_col}")

--- a/map_point_parser.py
+++ b/map_point_parser.py
@@ -6,6 +6,7 @@ import html
 import pandas as pd
 import requests
 import streamlit as st
+import xyzservices.providers as xyz_providers
 from jinja2 import Template
 from streamlit_folium import st_folium
 
@@ -14,8 +15,47 @@ from google_sheets_parser import import_from_google_sheets
 from styling import DEFAULT_BUTTON_COLOR
 
 NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
-USER_AGENT = "click2vector/0.9.1"
-BASEMAP_OPTIONS = ["CartoDB Positron", "OpenStreetMap"]
+USER_AGENT = "click2vector/0.10.0"
+DEFAULT_BASEMAP = "CartoDB.PositronNoLabels"
+LEGACY_BASEMAP_NAMES = {
+    "CartoDB Positron": "CartoDB.Positron",
+    "OpenStreetMap": "CartoDB.PositronNoLabels",
+}
+BASEMAP_PROVIDER_GROUPS = (
+    "CartoDB",
+    "Esri",
+)
+BASEMAP_EXCLUDED_NAME_PARTS = (
+    "OnlyLabels",
+    "LabelsUnder",
+    "Lines",
+    "Background",
+    "overlay",
+    "HillShading",
+    "pistes",
+    "Reference",
+    "Arctic",
+    "Antarctic",
+    "LandLot",
+)
+BASEMAP_EXCLUDED_TILES = frozenset(
+    {
+        "Esri.NatGeoWorldMap",
+        "Esri.WorldShadedRelief",
+        "Esri.WorldTerrain",
+    }
+)
+BASEMAP_URL_KEY_PARTS = ("{apikey}", "{access_token}", "{token}", "{key}")
+BASEMAP_API_KEY_DOMAINS = (
+    "stadiamaps.com",
+    "jawg.io",
+    "api.mapbox.com",
+    "thunderforest.com",
+    "maptiler.com",
+    "geoapify.com",
+    "locationiq.com",
+    "hereapi.com",
+)
 DESCRIPTION_COLOR_PALETTE = [
     "#4363d8",
     "#3cb44b",
@@ -33,6 +73,87 @@ TABLE_COLUMN_TO_PROPERTY = {
     "Description": "description",
 }
 COLOR_TABLE_COLUMNS = [2, 2, 1]
+
+
+def _is_excluded_basemap(name: str) -> bool:
+    """Return whether a tile name should be omitted from the basemap list."""
+    if name in BASEMAP_EXCLUDED_TILES:
+        return True
+    return any(part in name for part in BASEMAP_EXCLUDED_NAME_PARTS)
+
+
+def _provider_requires_api_key(url: str) -> bool:
+    """Return whether a tile URL likely requires an API key."""
+    lowered = url.lower()
+    if any(part in lowered for part in BASEMAP_URL_KEY_PARTS):
+        return True
+    return any(domain in lowered for domain in BASEMAP_API_KEY_DOMAINS)
+
+
+def _collect_provider_tiles(provider_name: str) -> list[str]:
+    """Return tile ids for one xyzservices provider group."""
+    provider = getattr(xyz_providers, provider_name, None)
+    if provider is None:
+        return []
+    if isinstance(provider, dict) and "url" in provider:
+        name = provider.get("name", provider_name)
+        if _is_excluded_basemap(name) or _provider_requires_api_key(provider["url"]):
+            return []
+        return [name]
+
+    tiles = []
+    for variant in provider.values():
+        if not isinstance(variant, dict) or "url" not in variant:
+            continue
+        name = variant.get("name", provider_name)
+        if _is_excluded_basemap(name):
+            continue
+        if _provider_requires_api_key(variant["url"]):
+            continue
+        tiles.append(name)
+    return tiles
+
+
+def build_basemap_options() -> list[str]:
+    """Return free raster basemap tile ids supported by Folium."""
+    options = []
+    seen: set[str] = set()
+    for provider_name in BASEMAP_PROVIDER_GROUPS:
+        for tile_name in _collect_provider_tiles(provider_name):
+            if tile_name in seen:
+                continue
+            options.append(tile_name)
+            seen.add(tile_name)
+    return options
+
+
+BASEMAP_OPTIONS = build_basemap_options()
+
+
+def format_basemap_label(tile_name: str) -> str:
+    """Return a readable label for one basemap tile id."""
+    provider, _, variant = tile_name.partition(".")
+    if not variant:
+        return tile_name
+
+    provider_labels = {
+        "CartoDB": "Carto",
+    }
+    provider_label = provider_labels.get(provider, provider)
+    variant_label = (
+        variant.replace("NoLabels", " (no labels)")
+        .replace("DarkMatter", "Dark Matter")
+        .replace("LabelsUnder", "Labels Under")
+    )
+    return f"{provider_label} · {variant_label}"
+
+
+def normalize_basemap_name(name: str) -> str:
+    """Return a valid basemap tile id, mapping legacy names when needed."""
+    normalized = LEGACY_BASEMAP_NAMES.get(name, name)
+    if normalized in BASEMAP_OPTIONS:
+        return normalized
+    return DEFAULT_BASEMAP
 
 
 def request_rerun() -> None:
@@ -161,17 +282,10 @@ def sync_basemap_choice() -> None:
     st.session_state.basemap_name = st.session_state.basemap_picker
 
 
-def sync_pin_color_choice() -> None:
-    """Persist pin color across reruns triggered before widgets render."""
-    st.session_state.pin_color = st.session_state.pin_color_picker
-
-
 def sync_map_style_from_pickers() -> None:
     """Copy widget values into persistent map style session state."""
     if "basemap_picker" in st.session_state:
         st.session_state.basemap_name = st.session_state.basemap_picker
-    if "pin_color_picker" in st.session_state:
-        st.session_state.pin_color = st.session_state.pin_color_picker
 
 
 def render_search_section() -> None:
@@ -195,36 +309,46 @@ def render_search_section() -> None:
                     request_rerun()
 
         with st.expander("Advanced options", expanded=False, type="compact"):
-            sheets_url = st.text_input(
-                "Public Google Sheet URL with `lat` and `lon` columns:",
-                placeholder="https://docs.google.com/spreadsheets/d/...#gid=0",
-                key="sheets_url_input",
-            )
-            coordinate_format = st.radio(
-                "Coordinate format to import from Google Sheet (if applicable):",
-                options=["Lat/Long", "WKT Geometry"],
-                index=0,
-                horizontal=True,
-            )
+            import_col, format_col = st.columns(2)
+            with import_col:
+                st.caption("Public Google Sheet URL with `lat` and `lon` columns:")
+                sheets_url = st.text_input(
+                    "Public Google Sheet URL with `lat` and `lon` columns:",
+                    placeholder="https://docs.google.com/spreadsheets/d/...#gid=0",
+                    key="sheets_url_input",
+                    label_visibility="collapsed",
+                )
+            with format_col:
+                st.caption(
+                    "Coordinate format to import from Google Sheet (if applicable):"
+                )
+                coordinate_format = st.radio(
+                    "Coordinate format to import from Google Sheet (if applicable):",
+                    options=["Lat/Long", "WKT Geometry"],
+                    index=0,
+                    label_visibility="collapsed",
+                )
             use_wkt = coordinate_format == "WKT Geometry"
+
             if "basemap_picker" not in st.session_state:
-                st.session_state.basemap_picker = st.session_state.basemap_name
-            if "pin_color_picker" not in st.session_state:
-                st.session_state.pin_color_picker = st.session_state.pin_color
-            st.radio(
+                st.session_state.basemap_picker = normalize_basemap_name(
+                    st.session_state.basemap_name
+                )
+            elif st.session_state.basemap_picker not in BASEMAP_OPTIONS:
+                st.session_state.basemap_picker = normalize_basemap_name(
+                    st.session_state.basemap_picker
+                )
+            st.caption("Basemap options:")
+            st.selectbox(
                 "Basemap options:",
                 options=BASEMAP_OPTIONS,
-                horizontal=True,
+                format_func=format_basemap_label,
                 key="basemap_picker",
                 on_change=sync_basemap_choice,
+                label_visibility="collapsed",
             )
+            st.caption("Map options:")
             st.checkbox("Show inset map", key="show_inset_map")
-            if not st.session_state.points:
-                st.color_picker(
-                    "Default pin color:",
-                    key="pin_color_picker",
-                    on_change=sync_pin_color_choice,
-                )
             sync_map_style_from_pickers()
 
             if sheets_url and sheets_url != st.session_state.get(
@@ -736,6 +860,50 @@ def add_existing_points_to_map(map_object):
         ).add_to(map_object)
 
 
+def _resolve_color_by_column_for_map() -> str:
+    """Return the active color-by column before Location table widgets render."""
+    colorable_columns = get_colorable_columns(st.session_state.points)
+    picker_value = st.session_state.get("color_by_column_picker")
+    if picker_value in colorable_columns:
+        return picker_value
+    return _resolve_color_by_column(colorable_columns)
+
+
+def _resolve_basemap_name() -> str:
+    """Return the active basemap tile id from session state."""
+    picker_value = st.session_state.get("basemap_picker")
+    if picker_value in BASEMAP_OPTIONS:
+        return picker_value
+    return normalize_basemap_name(st.session_state.get("basemap_name", DEFAULT_BASEMAP))
+
+
+def _map_widget_key() -> str:
+    """Return a st_folium key that changes when map layers need to refresh.
+
+    ``st_folium`` hashes only the Leaflet script when choosing a component key,
+    so HTML legend overlays and similar basemap variants can fail to update
+    unless the key changes too.
+    """
+    basemap = _resolve_basemap_name()
+    inset_enabled = st.session_state.get("show_inset_map", False)
+    key = f"click2vector_map_{basemap}_{inset_enabled}"
+
+    if not st.session_state.get("show_map_legend", False):
+        return key
+
+    default_color = st.session_state.get("pin_color", DEFAULT_BUTTON_COLOR)
+    color_by_column = _resolve_color_by_column_for_map()
+    property_key = get_property_key(color_by_column)
+    legend_parts = []
+    for value in get_unique_property_values(st.session_state.points, property_key):
+        default_label = value or f"(No {color_by_column.lower()})"
+        label = get_legend_display_name(property_key, value, default_label)
+        color = resolve_point_color(property_key, value, default_color)
+        legend_parts.append(f"{label}:{color}")
+    fingerprint = hashlib.sha256("|".join(legend_parts).encode()).hexdigest()[:12]
+    return f"{key}_legend_{fingerprint}"
+
+
 def add_map_color_legend(map_object: folium.Map) -> None:
     """Add a categorical color legend to the map when enabled.
 
@@ -757,7 +925,7 @@ def add_map_color_legend(map_object: folium.Map) -> None:
         return
 
     default_color = st.session_state.get("pin_color", DEFAULT_BUTTON_COLOR)
-    color_by_column = st.session_state.get("color_by_column", "Description")
+    color_by_column = _resolve_color_by_column_for_map()
     property_key = get_property_key(color_by_column)
     unique_values = get_unique_property_values(
         st.session_state.points, property_key
@@ -769,11 +937,12 @@ def add_map_color_legend(map_object: folium.Map) -> None:
         color = resolve_point_color(property_key, value, default_color)
         safe_label = html.escape(label)
         legend_rows.append(
-            f'<div style="display:flex;align-items:center;margin-bottom:4px;">'
-            f'<span style="background:{color};width:12px;height:12px;'
-            f"border-radius:50%;border:1px solid #ccc;flex-shrink:0;"
-            f'margin-right:8px;"></span>'
-            f'<span style="font-size:12px;line-height:1.2;">{safe_label}</span>'
+            f'<div style="display:flex;align-items:center;gap:8px;">'
+            f'<span style="background:{color};width:12px;height:12px;min-width:12px;'
+            f"border-radius:50%;border:1px solid #ccc;display:inline-block;"
+            f'box-sizing:border-box;flex-shrink:0;"></span>'
+            f'<span style="font-size:12px;line-height:12px;margin:0;">'
+            f"{safe_label}</span>"
             f"</div>"
         )
 
@@ -781,9 +950,10 @@ def add_map_color_legend(map_object: folium.Map) -> None:
         return
 
     legend_html = (
-        '<div style="position:absolute;bottom:24px;left:10px;z-index:1000;'
+        '<div style="position:fixed;bottom:24px;left:10px;z-index:10000;'
         "background:white;border:1px solid #ccc;border-radius:4px;"
-        'padding:8px 10px;max-width:220px;">'
+        "padding:8px 10px;max-width:220px;display:flex;"
+        'flex-direction:column;gap:4px;">'
         f'{"".join(legend_rows)}</div>'
     )
     map_object.get_root().html.add_child(Element(legend_html))
@@ -964,7 +1134,7 @@ def create_point_table():
     None
         Renders an interactive data table for point management.
     """
-    with st.expander("Point Table", expanded=True, type="compact"):
+    with st.expander("Location table", expanded=False, type="compact"):
         # Show points in a table
         points_data = []
         for point_index, point in enumerate(st.session_state.points):
@@ -1167,7 +1337,7 @@ def _render_interactive_map(basemap_name: str) -> dict | None:
             "last_object_clicked_tooltip",
         ],
         use_container_width=True,
-        key="click2vector_map",
+        key=_map_widget_key(),
     )
 
     if map_data and process_map_state(map_data):
@@ -1176,23 +1346,18 @@ def _render_interactive_map(basemap_name: str) -> dict | None:
     return map_data
 
 
-def render_map_interface(basemap_name):
+def render_map_interface() -> dict | None:
     """Main function to render the complete map interface.
-
-    Parameters
-    ----------
-    basemap_name : str
-        The name of the basemap to use.
 
     Returns
     -------
-    dict
+    dict or None
         The map data returned from st_folium for further processing.
     """
     # Create map with features
     render_search_section()
 
-    map_data = _render_interactive_map(basemap_name)
+    map_data = _render_interactive_map(_resolve_basemap_name())
 
     # Show point management controls if points exist
     if st.session_state.points:

--- a/map_point_parser.py
+++ b/map_point_parser.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import folium
 import hashlib
+import html
 import pandas as pd
 import requests
 import streamlit as st
@@ -9,10 +10,12 @@ from jinja2 import Template
 from streamlit_folium import st_folium
 
 from click_to_geojson_functionality import add_point
+from google_sheets_parser import import_from_google_sheets
 from styling import DEFAULT_BUTTON_COLOR
 
 NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
 USER_AGENT = "click2vector/0.9.1"
+BASEMAP_OPTIONS = ["CartoDB Positron", "OpenStreetMap"]
 DESCRIPTION_COLOR_PALETTE = [
     "#4363d8",
     "#3cb44b",
@@ -25,6 +28,11 @@ DESCRIPTION_COLOR_PALETTE = [
     "#800000",
     "#000075",
 ]
+TABLE_COLUMN_TO_PROPERTY = {
+    "Name": "name",
+    "Description": "description",
+}
+COLOR_TABLE_COLUMNS = [2, 2, 1]
 
 
 def request_rerun() -> None:
@@ -148,27 +156,89 @@ def add_searched_place(lat: float, lng: float, name: str) -> None:
     set_map_view(lat, lng)
 
 
-def render_place_search() -> None:
-    """Render a search field that geocodes a place and adds it as a point."""
-    with st.form("place_search_form"):
-        search_col, button_col = st.columns([4, 1], vertical_alignment="bottom")
-        with search_col:
+def sync_basemap_choice() -> None:
+    """Persist basemap selection across reruns triggered before widgets render."""
+    st.session_state.basemap_name = st.session_state.basemap_picker
+
+
+def sync_pin_color_choice() -> None:
+    """Persist pin color across reruns triggered before widgets render."""
+    st.session_state.pin_color = st.session_state.pin_color_picker
+
+
+def sync_map_style_from_pickers() -> None:
+    """Copy widget values into persistent map style session state."""
+    if "basemap_picker" in st.session_state:
+        st.session_state.basemap_name = st.session_state.basemap_picker
+    if "pin_color_picker" in st.session_state:
+        st.session_state.pin_color = st.session_state.pin_color_picker
+
+
+def render_search_section() -> None:
+    """Render place search and advanced map or import options."""
+    with st.container(border=False):
+        with st.form("place_search_form", border=False):
             query = st.text_input(
                 "Search for a place to add",
                 placeholder="e.g. Berlin",
             )
-        with button_col:
-            submitted = st.form_submit_button("Add pin", type="primary")
+            submitted = st.form_submit_button("\u200b")
 
-        if submitted and query.strip():
-            place = geocode_place_name(query.strip())
-            if place is None:
-                st.session_state.message = (
-                    f"No results found for '{query.strip()}'."
+            if submitted and query.strip():
+                place = geocode_place_name(query.strip())
+                if place is None:
+                    st.session_state.message = (
+                        f"No results found for '{query.strip()}'."
+                    )
+                else:
+                    add_searched_place(place["lat"], place["lng"], place["name"])
+                    request_rerun()
+
+        with st.expander("Advanced options", expanded=False, type="compact"):
+            sheets_url = st.text_input(
+                "Public Google Sheet URL with `lat` and `lon` columns:",
+                placeholder="https://docs.google.com/spreadsheets/d/...#gid=0",
+                key="sheets_url_input",
+            )
+            coordinate_format = st.radio(
+                "Coordinate format to import from Google Sheet (if applicable):",
+                options=["Lat/Long", "WKT Geometry"],
+                index=0,
+                horizontal=True,
+            )
+            use_wkt = coordinate_format == "WKT Geometry"
+            if "basemap_picker" not in st.session_state:
+                st.session_state.basemap_picker = st.session_state.basemap_name
+            if "pin_color_picker" not in st.session_state:
+                st.session_state.pin_color_picker = st.session_state.pin_color
+            st.radio(
+                "Basemap options:",
+                options=BASEMAP_OPTIONS,
+                horizontal=True,
+                key="basemap_picker",
+                on_change=sync_basemap_choice,
+            )
+            st.checkbox("Show inset map", key="show_inset_map")
+            if not st.session_state.points:
+                st.color_picker(
+                    "Default pin color:",
+                    key="pin_color_picker",
+                    on_change=sync_pin_color_choice,
                 )
-            else:
-                add_searched_place(place["lat"], place["lng"], place["name"])
-                request_rerun()
+            sync_map_style_from_pickers()
+
+            if sheets_url and sheets_url != st.session_state.get(
+                "last_sheets_url", ""
+            ):
+                st.session_state.last_sheets_url = sheets_url
+                success = import_from_google_sheets(sheets_url, use_wkt)
+                if success:
+                    request_rerun()
+
+
+def render_place_search() -> None:
+    """Render a search field that geocodes a place and adds it as a point."""
+    render_search_section()
 
 
 def add_draggable_marker_handlers(map_object: folium.Map) -> None:
@@ -288,6 +358,11 @@ def create_map_with_features(basemap_name):
         tiles=basemap_name,
     )
 
+    folium.plugins.Fullscreen(
+        position="topright",
+        force_separate_button=True,
+    ).add_to(map_object)
+
     # Add an inset map (mini map) when enabled
     if st.session_state.get("show_inset_map", False):
         mini_map = folium.plugins.MiniMap(
@@ -306,8 +381,24 @@ def create_map_with_features(basemap_name):
     return map_object
 
 
-def get_unique_descriptions(points: list[dict]) -> list[str]:
-    """Return sorted unique description values across all points.
+def get_property_key(column_name: str) -> str:
+    """Return the point property key for a table column label.
+
+    Parameters
+    ----------
+    column_name : str
+        Display name from the point table.
+
+    Returns
+    -------
+    str
+        Property key stored on each point.
+    """
+    return TABLE_COLUMN_TO_PROPERTY.get(column_name, column_name)
+
+
+def get_colorable_columns(points: list[dict]) -> list[str]:
+    """Return table columns that can drive pin colors.
 
     Parameters
     ----------
@@ -317,35 +408,97 @@ def get_unique_descriptions(points: list[dict]) -> list[str]:
     Returns
     -------
     list of str
-        Sorted unique descriptions; empty string means no description.
+        Column labels shown in the color-by dropdown.
     """
-    return sorted(
-        {
-            point["properties"].get("description", "").strip()
-            for point in points
-        }
-    )
+    columns = ["Name", "Description"]
+    seen = set(columns)
+    for point in points:
+        for key in point["properties"]:
+            if key in ("name", "description", "timestamp"):
+                continue
+            if key not in seen:
+                columns.append(key)
+                seen.add(key)
+    return columns
 
 
-def sync_description_color_state(points: list[dict], default_color: str) -> None:
-    """Assign default colors to new descriptions and drop stale entries.
+def get_point_property_value(point: dict, property_key: str) -> str:
+    """Return one normalized property value from a point.
+
+    Parameters
+    ----------
+    point : dict
+        GeoJSON feature dictionary.
+    property_key : str
+        Property key to read from the point.
+
+    Returns
+    -------
+    str
+        Stripped string value for the property.
+    """
+    return str(point["properties"].get(property_key, "")).strip()
+
+
+def get_unique_property_values(points: list[dict], property_key: str) -> list[str]:
+    """Return sorted unique values for one property across all points.
 
     Parameters
     ----------
     points : list of dict
         GeoJSON feature dictionaries from session state.
+    property_key : str
+        Property key to collect values from.
+
+    Returns
+    -------
+    list of str
+        Sorted unique property values; empty string means no value set.
+    """
+    return sorted(
+        {get_point_property_value(point, property_key) for point in points}
+    )
+
+
+def _get_property_colors(property_key: str) -> dict[str, str]:
+    """Return the color map for one property, creating it if needed.
+
+    Parameters
+    ----------
+    property_key : str
+        Property key whose value-to-color map is requested.
+
+    Returns
+    -------
+    dict of str to str
+        Mapping from property value to hex color.
+    """
+    if "property_value_colors" not in st.session_state:
+        st.session_state.property_value_colors = {}
+    return st.session_state.property_value_colors.setdefault(property_key, {})
+
+
+def sync_property_color_state(
+    points: list[dict], property_key: str, default_color: str
+) -> None:
+    """Assign default colors to new property values and drop stale entries.
+
+    Parameters
+    ----------
+    points : list of dict
+        GeoJSON feature dictionaries from session state.
+    property_key : str
+        Property key used for pin coloring.
     default_color : str
         Default pin color used when assigning palette colors.
 
     Returns
     -------
     None
-        Updates ``description_colors`` in session state.
+        Updates ``property_value_colors`` in session state.
     """
-    if "description_colors" not in st.session_state:
-        st.session_state.description_colors = {}
-
-    unique_descriptions = get_unique_descriptions(points)
+    colors = _get_property_colors(property_key)
+    unique_values = get_unique_property_values(points, property_key)
     palette = [
         color
         for color in DESCRIPTION_COLOR_PALETTE
@@ -354,23 +507,21 @@ def sync_description_color_state(points: list[dict], default_color: str) -> None
     if not palette:
         palette = DESCRIPTION_COLOR_PALETTE
 
-    for index, description in enumerate(unique_descriptions):
-        if description not in st.session_state.description_colors:
-            if len(unique_descriptions) == 1:
-                st.session_state.description_colors[description] = default_color
+    for index, value in enumerate(unique_values):
+        if value not in colors:
+            if len(unique_values) == 1:
+                colors[value] = default_color
             else:
-                st.session_state.description_colors[description] = palette[
-                    index % len(palette)
-                ]
+                colors[value] = palette[index % len(palette)]
 
-    for stale_description in set(st.session_state.description_colors) - set(
-        unique_descriptions
-    ):
-        del st.session_state.description_colors[stale_description]
+    for stale_value in set(colors) - set(unique_values):
+        del colors[stale_value]
 
 
-def sync_description_colors_from_pickers(points: list[dict]) -> None:
-    """Copy color picker widget values into ``description_colors``.
+def sync_property_colors_from_pickers(
+    points: list[dict], property_key: str
+) -> None:
+    """Copy color picker widget values into ``property_value_colors``.
 
     Streamlit updates widget session state before the script runs, but the map
     is rendered above the pickers. Syncing here ensures marker colors reflect
@@ -380,46 +531,51 @@ def sync_description_colors_from_pickers(points: list[dict]) -> None:
     ----------
     points : list of dict
         GeoJSON feature dictionaries from session state.
+    property_key : str
+        Property key used for pin coloring.
 
     Returns
     -------
     None
-        Updates ``description_colors`` in session state.
+        Updates ``property_value_colors`` in session state.
     """
-    if "description_colors" not in st.session_state:
-        st.session_state.description_colors = {}
-
-    for description in get_unique_descriptions(points):
-        picker_key = f"desc_color_picker_{_description_color_widget_key(description)}"
+    colors = _get_property_colors(property_key)
+    for value in get_unique_property_values(points, property_key):
+        picker_key = _property_color_widget_key(property_key, value)
         if picker_key in st.session_state:
-            st.session_state.description_colors[description] = st.session_state[
-                picker_key
-            ]
+            colors[value] = st.session_state[picker_key]
 
 
-def _description_color_widget_key(description: str) -> str:
-    """Return a stable widget key suffix for a description value.
+def _property_color_widget_key(property_key: str, value: str) -> str:
+    """Return a stable widget key suffix for one property value.
 
     Parameters
     ----------
-    description : str
-        Point description text.
+    property_key : str
+        Property key used for pin coloring.
+    value : str
+        Property value assigned a pin color.
 
     Returns
     -------
     str
-        Short hash string safe for Streamlit widget keys.
+        Streamlit widget key for the value's color picker.
     """
-    return hashlib.sha256(description.encode()).hexdigest()[:16]
+    digest = hashlib.sha256(f"{property_key}:{value}".encode()).hexdigest()[:16]
+    return f"prop_color_picker_{digest}"
 
 
-def resolve_point_color(description: str, default_color: str) -> str:
-    """Return the marker color for a point from its description.
+def resolve_point_color(
+    property_key: str, value: str, default_color: str
+) -> str:
+    """Return the marker color for a point from one property value.
 
     Parameters
     ----------
-    description : str
-        Point description text.
+    property_key : str
+        Property key used for pin coloring.
+    value : str
+        Property value for the point.
     default_color : str
         Fallback color when no mapping exists yet.
 
@@ -428,10 +584,100 @@ def resolve_point_color(description: str, default_color: str) -> str:
     str
         Hex color code for the marker.
     """
-    normalized = (description or "").strip()
-    return st.session_state.get("description_colors", {}).get(
-        normalized, default_color
-    )
+    normalized = (value or "").strip()
+    colors = st.session_state.get("property_value_colors", {}).get(property_key, {})
+    return colors.get(normalized, default_color)
+
+
+def _get_legend_display_names(property_key: str) -> dict[str, str]:
+    """Return the legend label map for one property, creating it if needed.
+
+    Parameters
+    ----------
+    property_key : str
+        Property key used for pin coloring.
+
+    Returns
+    -------
+    dict of str to str
+        Mapping from property value to custom legend label.
+    """
+    if "legend_display_names" not in st.session_state:
+        st.session_state.legend_display_names = {}
+    return st.session_state.legend_display_names.setdefault(property_key, {})
+
+
+def get_legend_display_name(
+    property_key: str, value: str, default_label: str
+) -> str:
+    """Return the legend label for one property value.
+
+    Parameters
+    ----------
+    property_key : str
+        Property key used for pin coloring.
+    value : str
+        Property value for the point.
+    default_label : str
+        Fallback label when no custom name is stored.
+
+    Returns
+    -------
+    str
+        Label shown in the map legend.
+    """
+    stored = _get_legend_display_names(property_key).get(value)
+    if stored is not None and stored.strip():
+        return stored.strip()
+    return default_label
+
+
+def sync_legend_display_names_from_inputs(
+    points: list[dict], property_key: str
+) -> None:
+    """Copy legend label widget values into ``legend_display_names``.
+
+    Parameters
+    ----------
+    points : list of dict
+        GeoJSON feature dictionaries from session state.
+    property_key : str
+        Property key used for pin coloring.
+
+    Returns
+    -------
+    None
+        Updates ``legend_display_names`` in session state.
+    """
+    names = _get_legend_display_names(property_key)
+    unique_values = get_unique_property_values(points, property_key)
+    for value in unique_values:
+        widget_key = _legend_label_widget_key(property_key, value)
+        if widget_key in st.session_state:
+            names[value] = st.session_state[widget_key]
+    for stale_value in set(names) - set(unique_values):
+        del names[stale_value]
+
+
+def _legend_label_widget_key(property_key: str, value: str) -> str:
+    """Return a stable widget key suffix for one legend label input.
+
+    Parameters
+    ----------
+    property_key : str
+        Property key used for pin coloring.
+    value : str
+        Property value assigned a legend label.
+
+    Returns
+    -------
+    str
+        Streamlit widget key for the legend label input.
+    """
+    digest = hashlib.sha256(
+        f"legend:{property_key}:{value}".encode()
+    ).hexdigest()[:16]
+    return f"legend_label_{digest}"
 
 
 def make_pin_div_icon(color: str) -> folium.DivIcon:
@@ -474,11 +720,13 @@ def add_existing_points_to_map(map_object):
         Adds markers for all existing points to the map.
     """
     default_color = st.session_state.get("pin_color", DEFAULT_BUTTON_COLOR)
+    color_by_column = st.session_state.get("color_by_column", "Description")
+    property_key = get_property_key(color_by_column)
 
     for point_index, point in enumerate(st.session_state.points):
         coords = point["geometry"]["coordinates"]
-        description = point["properties"].get("description", "")
-        pin_color = resolve_point_color(description, default_color)
+        value = get_point_property_value(point, property_key)
+        pin_color = resolve_point_color(property_key, value, default_color)
 
         folium.Marker(
             location=[coords[1], coords[0]],  # Note: folium uses [lat, lon]
@@ -486,6 +734,59 @@ def add_existing_points_to_map(map_object):
             icon=make_pin_div_icon(pin_color),
             draggable=True,
         ).add_to(map_object)
+
+
+def add_map_color_legend(map_object: folium.Map) -> None:
+    """Add a categorical color legend to the map when enabled.
+
+    Parameters
+    ----------
+    map_object : folium.Map
+        The folium map to add the legend to.
+
+    Returns
+    -------
+    None
+        Adds a legend element to the map when ``show_map_legend`` is enabled.
+    """
+    from folium import Element
+
+    if not st.session_state.get("show_map_legend", False):
+        return
+    if not st.session_state.points:
+        return
+
+    default_color = st.session_state.get("pin_color", DEFAULT_BUTTON_COLOR)
+    color_by_column = st.session_state.get("color_by_column", "Description")
+    property_key = get_property_key(color_by_column)
+    unique_values = get_unique_property_values(
+        st.session_state.points, property_key
+    )
+    legend_rows = []
+    for value in unique_values:
+        default_label = value or f"(No {color_by_column.lower()})"
+        label = get_legend_display_name(property_key, value, default_label)
+        color = resolve_point_color(property_key, value, default_color)
+        safe_label = html.escape(label)
+        legend_rows.append(
+            f'<div style="display:flex;align-items:center;margin-bottom:4px;">'
+            f'<span style="background:{color};width:12px;height:12px;'
+            f"border-radius:50%;border:1px solid #ccc;flex-shrink:0;"
+            f'margin-right:8px;"></span>'
+            f'<span style="font-size:12px;line-height:1.2;">{safe_label}</span>'
+            f"</div>"
+        )
+
+    if not legend_rows:
+        return
+
+    legend_html = (
+        '<div style="position:absolute;bottom:24px;left:10px;z-index:1000;'
+        "background:white;border:1px solid #ccc;border-radius:4px;"
+        'padding:8px 10px;max-width:220px;">'
+        f'{"".join(legend_rows)}</div>'
+    )
+    map_object.get_root().html.add_child(Element(legend_html))
 
 
 def handle_map_clicks(map_data):
@@ -628,35 +929,31 @@ def process_map_state(map_state: dict) -> bool:
     return handle_map_interactions(map_state)
 
 
-def create_point_management_controls():
-    """Create controls for managing points (remove last, clear all).
+def _sync_points_table_changes() -> None:
+    """Apply row deletions and edits from the point table data editor."""
+    state = st.session_state.get("points_table")
+    if not state:
+        return
 
-    Returns
-    -------
-    None
-        Renders point management buttons in the Streamlit interface.
-    """
-    col1, col2, col3, col4 = st.columns([1.5, 2, 2, 1])
+    changed = False
 
-    with col2:
-        if st.button("Remove Last Point", key="remove_last_point"):
-            try:
-                st.session_state.points.pop()
-                request_rerun()
-            except IndexError:
-                # No points to remove
-                pass
+    for idx in sorted(state.get("deleted_rows", []), reverse=True):
+        if 0 <= idx < len(st.session_state.points):
+            st.session_state.points.pop(idx)
+            changed = True
 
-    with col3:
-        if st.button("Clear All Points", key="clear_all_points_quick"):
-            try:
-                from click_to_geojson_functionality import reset_points
+    for idx, updates in state.get("edited_rows", {}).items():
+        point_idx = int(idx)
+        if 0 <= point_idx < len(st.session_state.points):
+            properties = st.session_state.points[point_idx]["properties"]
+            if "Name" in updates:
+                properties["name"] = str(updates["Name"])
+            if "Description" in updates:
+                properties["description"] = str(updates["Description"])
+            changed = True
 
-                reset_points()
-                request_rerun()
-            except Exception:
-                # No points to clear or other error
-                pass
+    if changed:
+        request_rerun()
 
 
 def create_point_table():
@@ -667,7 +964,7 @@ def create_point_table():
     None
         Renders an interactive data table for point management.
     """
-    with st.expander("Point Table", expanded=True):
+    with st.expander("Point Table", expanded=True, type="compact"):
         # Show points in a table
         points_data = []
         for point_index, point in enumerate(st.session_state.points):
@@ -702,6 +999,8 @@ def create_point_table():
             df[display_columns],
             width="stretch",
             key="points_table",
+            num_rows="delete",
+            on_change=_sync_points_table_changes,
             column_config={
                 "Name": st.column_config.TextColumn("Name", disabled=False),
                 "Description": st.column_config.TextColumn(
@@ -716,7 +1015,6 @@ def create_point_table():
             },
         )
 
-        # Handle name and description changes
         if edited_df is not None:
             for i, row in edited_df.iterrows():
                 try:
@@ -725,74 +1023,121 @@ def create_point_table():
                         "Description"
                     ]
                 except IndexError:
-                    # Skip if this is the extra "add row" row
                     pass
 
-        render_description_color_table()
-
-        # Handle row selection for deletion
-        try:
-            selected_rows = st.session_state.points_table.get("selected_rows", [])
-            if selected_rows:
-                # Delete selected points (in reverse order to maintain indices)
-                for row in reversed(selected_rows):
-                    try:
-                        index_to_remove = row["Index"]
-                        if 0 <= index_to_remove < len(st.session_state.points):
-                            st.session_state.points.pop(index_to_remove)
-                    except (KeyError, IndexError):
-                        # Invalid row data or index
-                        continue
-                request_rerun()
-        except (KeyError, AttributeError):
-            # No points_table in session state or no selected_rows
-            pass
+        render_property_color_table()
 
 
-def _sync_description_color(description: str) -> None:
-    """Persist one description color picker value in session state."""
-    picker_key = f"desc_color_picker_{_description_color_widget_key(description)}"
-    st.session_state.description_colors[description] = st.session_state[picker_key]
+def _sync_property_color(property_key: str, value: str) -> None:
+    """Persist one property color picker value in session state."""
+    picker_key = _property_color_widget_key(property_key, value)
+    colors = _get_property_colors(property_key)
+    colors[value] = st.session_state[picker_key]
 
 
-def render_description_color_table() -> None:
-    """Render unique descriptions and a pin color picker for each."""
+def _sync_color_by_column() -> None:
+    """Persist the selected color-by column across reruns."""
+    st.session_state.color_by_column = st.session_state.color_by_column_picker
+
+
+def _resolve_color_by_column(colorable_columns: list[str]) -> str:
+    """Return a valid color-by column from session state.
+
+    Parameters
+    ----------
+    colorable_columns : list of str
+        Column labels available for pin coloring.
+
+    Returns
+    -------
+    str
+        Selected column label, falling back to ``Description`` when needed.
+    """
+    current = st.session_state.get("color_by_column", "Description")
+    if current in colorable_columns:
+        return current
+    if "Description" in colorable_columns:
+        return "Description"
+    return colorable_columns[0]
+
+
+def render_property_color_table() -> None:
+    """Render the color-by column selector and pin color pickers."""
     default_color = st.session_state.get("pin_color", DEFAULT_BUTTON_COLOR)
-    sync_description_color_state(st.session_state.points, default_color)
+    colorable_columns = get_colorable_columns(st.session_state.points)
+    color_by_column = _resolve_color_by_column(colorable_columns)
 
-    unique_descriptions = get_unique_descriptions(st.session_state.points)
-    st.markdown("**Pin colors by description**")
-    header_desc, header_color = st.columns([3, 1])
-    with header_desc:
-        st.markdown("Description")
+    if "color_by_column_picker" not in st.session_state:
+        st.session_state.color_by_column_picker = color_by_column
+    elif st.session_state.color_by_column_picker not in colorable_columns:
+        st.session_state.color_by_column_picker = color_by_column
+
+    color_by_col, legend_toggle_col, _ = st.columns(
+        COLOR_TABLE_COLUMNS, vertical_alignment="bottom"
+    )
+    with color_by_col:
+        st.selectbox(
+            "Color points by:",
+            options=colorable_columns,
+            key="color_by_column_picker",
+            on_change=_sync_color_by_column,
+        )
+    with legend_toggle_col:
+        st.checkbox("Show legend on map", key="show_map_legend")
+
+    st.session_state.color_by_column = st.session_state.color_by_column_picker
+    property_key = get_property_key(st.session_state.color_by_column)
+
+    sync_property_color_state(st.session_state.points, property_key, default_color)
+
+    unique_values = get_unique_property_values(
+        st.session_state.points, property_key
+    )
+    colors = _get_property_colors(property_key)
+    column_label = st.session_state.color_by_column
+    legend_names = _get_legend_display_names(property_key)
+
+    header_value, header_legend, header_color = st.columns(COLOR_TABLE_COLUMNS)
+    with header_value:
+        st.caption("Value")
+    with header_legend:
+        st.caption("Legend Display Name")
     with header_color:
-        st.markdown("Pin color")
+        st.caption("Point Color")
 
-    for description in unique_descriptions:
-        label = description or "(No description)"
-        desc_col, color_col = st.columns([3, 1])
-        with desc_col:
-            st.text(label)
-        with color_col:
-            picker_key = (
-                f"desc_color_picker_{_description_color_widget_key(description)}"
+    for value in unique_values:
+        category_label = value or f"(No {column_label.lower()})"
+        category_col, legend_col, color_col = st.columns(COLOR_TABLE_COLUMNS)
+        with category_col:
+            st.text(category_label)
+        with legend_col:
+            label_key = _legend_label_widget_key(property_key, value)
+            if label_key not in st.session_state:
+                st.session_state[label_key] = legend_names.get(
+                    value, category_label
+                )
+            st.text_input(
+                "Legend Display Name",
+                key=label_key,
+                label_visibility="collapsed",
             )
+            legend_names[value] = st.session_state[label_key]
+        with color_col:
+            picker_key = _property_color_widget_key(property_key, value)
             if picker_key not in st.session_state:
-                st.session_state[picker_key] = st.session_state.description_colors[
-                    description
-                ]
+                st.session_state[picker_key] = colors[value]
             st.color_picker(
-                label,
+                category_label,
                 key=picker_key,
                 label_visibility="collapsed",
-                on_change=_sync_description_color,
-                args=(description,),
+                on_change=_sync_property_color,
+                args=(property_key, value),
             )
-            _sync_description_color(description)
+            _sync_property_color(property_key, value)
 
 
-def render_map_interface(basemap_name):
-    """Main function to render the complete map interface.
+def _render_interactive_map(basemap_name: str) -> dict | None:
+    """Build and display the folium map, returning st_folium output.
 
     Parameters
     ----------
@@ -801,20 +1146,16 @@ def render_map_interface(basemap_name):
 
     Returns
     -------
-    dict
+    dict or None
         The map data returned from st_folium for further processing.
     """
-    # Create map with features
-    render_place_search()
-
     map_object = create_map_with_features(basemap_name)
     map_view = st.session_state.get("last_map_view", get_default_map_view())
 
-    # Add existing points to map
     add_existing_points_to_map(map_object)
+    add_map_color_legend(map_object)
     add_draggable_marker_handlers(map_object)
 
-    # Display the map and capture clicks
     map_data = st_folium(
         map_object,
         height=300,
@@ -832,9 +1173,29 @@ def render_map_interface(basemap_name):
     if map_data and process_map_state(map_data):
         request_rerun()
 
+    return map_data
+
+
+def render_map_interface(basemap_name):
+    """Main function to render the complete map interface.
+
+    Parameters
+    ----------
+    basemap_name : str
+        The name of the basemap to use.
+
+    Returns
+    -------
+    dict
+        The map data returned from st_folium for further processing.
+    """
+    # Create map with features
+    render_search_section()
+
+    map_data = _render_interactive_map(basemap_name)
+
     # Show point management controls if points exist
     if st.session_state.points:
-        create_point_management_controls()
         create_point_table()
 
     return map_data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "click2vector"
-version = "0.9.1"
+version = "0.10.0"
 description = "Interactive map application for creating and exporting GeoJSON points"
 authors = ["Chiara Phillips <contact@chiaraphillips.com>"]
 readme = "README.md"

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -11,6 +11,7 @@ from click_to_geojson_functionality import (
     points_to_gdf,
 )
 from map_point_parser import (
+    DEFAULT_BASEMAP,
     get_property_key,
     render_map_interface,
     sync_legend_display_names_from_inputs,
@@ -31,7 +32,7 @@ if "last_click" not in st.session_state:
 if "message" not in st.session_state:
     st.session_state.message = None
 if "basemap_name" not in st.session_state:
-    st.session_state.basemap_name = "CartoDB Positron"
+    st.session_state.basemap_name = DEFAULT_BASEMAP
 if "pin_color" not in st.session_state:
     st.session_state.pin_color = DEFAULT_BUTTON_COLOR
 if "color_by_column" not in st.session_state:
@@ -63,7 +64,7 @@ if st.session_state.points:
     )
 
 # Main app
-render_map_interface(st.session_state.basemap_name)
+render_map_interface()
 
 if st.session_state.message:
     if (
@@ -80,42 +81,49 @@ if st.session_state.points:
         st.session_state.custom_filename = get_base_filename()
 
     with st.container(border=False):
-        type_col, name_col = st.columns(2)
-        with type_col:
-            export_type = st.radio(
-                "Export file type:",
-                options=["GeoJSON", "Esri Shapefile (.zip)", "FlatGeobuf"],
-                index=0,
-                key="export_type_radio",
-            )
-        with name_col:
-            custom_filename = st.text_input(
-                "Export filename:",
-                value=st.session_state.custom_filename,
-                placeholder="Enter export filename",
-                key="filename_input",
-            )
+        with st.expander(
+            "Export settings", expanded=False, type="compact"
+        ):
+            type_col, name_col = st.columns(2)
+            with type_col:
+                st.caption("Export file type:")
+                export_type = st.radio(
+                    "Export file type:",
+                    options=["GeoJSON", "Esri Shapefile (.zip)", "FlatGeobuf"],
+                    index=0,
+                    key="export_type_radio",
+                    label_visibility="collapsed",
+                )
+            with name_col:
+                st.caption("Export filename:")
+                custom_filename = st.text_input(
+                    "Export filename:",
+                    value=st.session_state.custom_filename,
+                    placeholder="Enter export filename",
+                    key="filename_input",
+                    label_visibility="collapsed",
+                )
 
-        st.session_state.custom_filename = custom_filename
+            st.session_state.custom_filename = custom_filename
 
-        if custom_filename.strip() and custom_filename.strip() != get_base_filename():
-            filename = custom_filename.strip()
-        else:
-            filename = get_base_filename()
+            if custom_filename.strip() and custom_filename.strip() != get_base_filename():
+                filename = custom_filename.strip()
+            else:
+                filename = get_base_filename()
 
-        gdf = points_to_gdf(st.session_state.points)
-        export_filename = build_export_filename(filename, export_type)
+            gdf = points_to_gdf(st.session_state.points)
+            export_filename = build_export_filename(filename, export_type)
+
+            if export_type == "GeoJSON":
+                with st.expander("GeoJSON output", expanded=False, type="compact"):
+                    st.code(export_data(gdf, export_type), language="json")
+
         export_mime = {
             "GeoJSON": "application/geo+json",
             "GeoJSON.io": "text/plain",
             "Esri Shapefile (.zip)": "application/zip",
             "FlatGeobuf": "application/octet-stream",
         }[export_type]
-
-        with type_col:
-            if export_type == "GeoJSON":
-                with st.expander("GeoJSON output", expanded=False, type="compact"):
-                    st.code(export_data(gdf, export_type), language="json")
 
         _, download_col, _ = st.columns([1, 1, 1])
         with download_col:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -10,34 +10,14 @@ from click_to_geojson_functionality import (
     get_base_filename,
     points_to_gdf,
 )
-from google_sheets_parser import import_from_google_sheets
 from map_point_parser import (
+    get_property_key,
     render_map_interface,
-    sync_description_color_state,
-    sync_description_colors_from_pickers,
+    sync_legend_display_names_from_inputs,
+    sync_property_color_state,
+    sync_property_colors_from_pickers,
 )
-from styling import DEFAULT_BUTTON_COLOR, create_styled_title, inject_global_css
-
-BASEMAP_OPTIONS = ["CartoDB Positron", "OpenStreetMap"]
-
-
-def sync_basemap_choice() -> None:
-    """Persist basemap selection across reruns triggered before widgets render."""
-    st.session_state.basemap_name = st.session_state.basemap_picker
-
-
-def sync_pin_color_choice() -> None:
-    """Persist pin color across reruns triggered before widgets render."""
-    st.session_state.pin_color = st.session_state.pin_color_picker
-
-
-def sync_map_style_from_pickers() -> None:
-    """Copy widget values into persistent map style session state."""
-    if "basemap_picker" in st.session_state:
-        st.session_state.basemap_name = st.session_state.basemap_picker
-    if "pin_color_picker" in st.session_state:
-        st.session_state.pin_color = st.session_state.pin_color_picker
-
+from styling import DEFAULT_BUTTON_COLOR, inject_global_css
 
 # Set page config
 st.set_page_config(page_title="Map to GeoJSON Exporter", layout="centered")
@@ -54,138 +34,99 @@ if "basemap_name" not in st.session_state:
     st.session_state.basemap_name = "CartoDB Positron"
 if "pin_color" not in st.session_state:
     st.session_state.pin_color = DEFAULT_BUTTON_COLOR
-if "description_colors" not in st.session_state:
-    st.session_state.description_colors = {}
+if "color_by_column" not in st.session_state:
+    st.session_state.color_by_column = "Description"
+if "property_value_colors" not in st.session_state:
+    st.session_state.property_value_colors = {}
+if "legend_display_names" not in st.session_state:
+    st.session_state.legend_display_names = {}
 if "show_inset_map" not in st.session_state:
     st.session_state.show_inset_map = False
+if "show_map_legend" not in st.session_state:
+    st.session_state.show_map_legend = False
 
 
 if st.session_state.points:
-    sync_description_color_state(
+    color_property_key = get_property_key(
+        st.session_state.get("color_by_column", "Description")
+    )
+    sync_property_color_state(
         st.session_state.points,
+        color_property_key,
         st.session_state.pin_color,
     )
-    sync_description_colors_from_pickers(st.session_state.points)
+    sync_property_colors_from_pickers(
+        st.session_state.points, color_property_key
+    )
+    sync_legend_display_names_from_inputs(
+        st.session_state.points, color_property_key
+    )
 
 # Main app
 render_map_interface(st.session_state.basemap_name)
 
-with st.expander("Advanced options", expanded=False):
-    col1, col2, col3 = st.columns([1, 1, 1])
-    with col2:
-        coordinate_format = st.radio(
-            "Coordinate format to import from Google Sheet (if applicable):",
-            options=["Lat/Long", "WKT Geometry"],
-            index=0,  # Default to Lat/Long
-            horizontal=True,
-        )
+if st.session_state.message:
+    if (
+        "error" in st.session_state.message.lower()
+        or "no points" in st.session_state.message.lower()
+    ):
+        st.error(st.session_state.message)
+    else:
+        st.success(st.session_state.message)
+    st.session_state.message = None
 
-        # Convert radio selection to boolean for the function
-        use_wkt = coordinate_format == "WKT Geometry"
-        column_text = (
-            "a `wkt_geom` column" if use_wkt else "`lat` and `long` columns"
-        )
-    with col1:
-        sheets_url = st.text_input(
-            f"Public Google Sheet URL with {column_text} (if applicable):",
-            placeholder="https://docs.google.com/spreadsheets/d/...",
-            key="sheets_url_input",
-        )
-    with col3:
-        if "basemap_picker" not in st.session_state:
-            st.session_state.basemap_picker = st.session_state.basemap_name
-        if "pin_color_picker" not in st.session_state:
-            st.session_state.pin_color_picker = st.session_state.pin_color
-        st.radio(
-            "Basemap options:",
-            options=BASEMAP_OPTIONS,
-            horizontal=True,
-            key="basemap_picker",
-            on_change=sync_basemap_choice,
-        )
-        st.checkbox("Show inset map", key="show_inset_map")
-        if not st.session_state.points:
-            st.color_picker(
-                "Default pin color:",
-                key="pin_color_picker",
-                on_change=sync_pin_color_choice,
-            )
-        sync_map_style_from_pickers()
-
-    if sheets_url and sheets_url != st.session_state.get("last_sheets_url", ""):
-        st.session_state.last_sheets_url = sheets_url
-        success = import_from_google_sheets(sheets_url, use_wkt)
-        if success:
-            st.rerun()
-
-    if st.session_state.points:
-        export_type = st.radio(
-            "Export file type:",
-            options=["GeoJSON", "Esri Shapefile (.zip)", "FlatGeobuf"],
-            index=0,
-            horizontal=True,
-            key="export_type_radio",
-        )
-        if export_type == "GeoJSON":
-            gdf = points_to_gdf(st.session_state.points)
-            with st.expander("GeoJSON output", expanded=False):
-                st.code(export_data(gdf, export_type), language="json")
-
-
-# Only show export options if points exist
 if st.session_state.points:
-    export_type = st.session_state.get("export_type_radio", "GeoJSON")
-
     if "custom_filename" not in st.session_state:
         st.session_state.custom_filename = get_base_filename()
 
-    custom_filename = st.text_input(
-        "Export filename:",
-        value=st.session_state.custom_filename,
-        placeholder="Enter export filename",
-        key="filename_input",
-    )
+    with st.container(border=False):
+        type_col, name_col = st.columns(2)
+        with type_col:
+            export_type = st.radio(
+                "Export file type:",
+                options=["GeoJSON", "Esri Shapefile (.zip)", "FlatGeobuf"],
+                index=0,
+                key="export_type_radio",
+            )
+        with name_col:
+            custom_filename = st.text_input(
+                "Export filename:",
+                value=st.session_state.custom_filename,
+                placeholder="Enter export filename",
+                key="filename_input",
+            )
 
-    st.session_state.custom_filename = custom_filename
+        st.session_state.custom_filename = custom_filename
 
-    if custom_filename.strip() and custom_filename.strip() != get_base_filename():
-        filename = custom_filename.strip()
-    else:
-        filename = get_base_filename()
-
-    gdf = points_to_gdf(st.session_state.points)
-
-    export_filename = build_export_filename(filename, export_type)
-
-    export_mime = {
-        "GeoJSON": "application/geo+json",
-        "GeoJSON.io": "text/plain",
-        "Esri Shapefile (.zip)": "application/zip",
-        "FlatGeobuf": "application/octet-stream",
-    }[export_type]
-
-    # Display any pending messages
-    if st.session_state.message:
-        if (
-            "error" in st.session_state.message.lower()
-            or "no points" in st.session_state.message.lower()
-        ):
-            st.error(st.session_state.message)
+        if custom_filename.strip() and custom_filename.strip() != get_base_filename():
+            filename = custom_filename.strip()
         else:
-            st.success(st.session_state.message)
-        st.session_state.message = None  # Clear the message
+            filename = get_base_filename()
 
-    # Show download button
-    col1, col2, col3 = st.columns([2, 2, 1])
-    with col2:
-        # Single download button for all formats
-        st.download_button(
-            label="Download Vector",
-            data=export_data(gdf, export_type),
-            file_name=export_filename,
-            mime=export_mime,
-            type="primary",
-        )
+        gdf = points_to_gdf(st.session_state.points)
+        export_filename = build_export_filename(filename, export_type)
+        export_mime = {
+            "GeoJSON": "application/geo+json",
+            "GeoJSON.io": "text/plain",
+            "Esri Shapefile (.zip)": "application/zip",
+            "FlatGeobuf": "application/octet-stream",
+        }[export_type]
+
+        with type_col:
+            if export_type == "GeoJSON":
+                with st.expander("GeoJSON output", expanded=False, type="compact"):
+                    st.code(export_data(gdf, export_type), language="json")
+
+        _, download_col, _ = st.columns([1, 1, 1])
+        with download_col:
+            st.download_button(
+                label="Download Vector",
+                data=export_data(gdf, export_type),
+                file_name=export_filename,
+                mime=export_mime,
+                type="primary",
+                use_container_width=True,
+            )
 
     st.markdown(
         """

--- a/styling.py
+++ b/styling.py
@@ -5,7 +5,6 @@ This module contains the styling for the Streamlit app.
 import streamlit as st
 
 DEFAULT_BUTTON_COLOR = "#f75f61"
-HOVER_BUTTON_COLOR = "#f97f81"
 
 
 def create_styled_title(
@@ -40,54 +39,28 @@ def create_styled_title(
 
 
 def inject_global_css() -> None:
-    """Inject custom global CSS styles into Streamlit app to standardize buttons look.
-
-    This function applies consistent styling to all `st.button` and `st.download_button`
-    elements across all pages in the app, including background color, text color,
-    border radius, padding, and hover/click effects.
+    """Inject custom global CSS styles into the Streamlit app.
 
     Returns
     -------
     None
-        CSS is injected directly into the Streamlit app via `st.markdown`.
+        CSS is injected directly into the Streamlit app via ``st.markdown``.
     """
     st.markdown(
-        f"""
+        """
             <link href="https://fonts.googleapis.com/css?family=Inter:400,500,600"
                   rel="stylesheet">
             <style>
-                /* Default Style for ALL Buttons (Generate & Download) */
-                div.stButton > button,
-                div.stDownloadButton > button {{
-                    background-color: {DEFAULT_BUTTON_COLOR} !important;
-                    color: white !important;
-                    border-radius: 100px !important;
-                    border: none;
-                    padding: 8px 16px;
-                    font-size: 16px;
-                    transition: 0.3s;
-                    font-family: 'Inter', system-ui, 'Segoe UI', Arial, sans-serif
-                    !important;
-                }}
-
-                /* Hover Effect for ALL Buttons */
-                div.stButton > button:hover,
-                div.stDownloadButton > button:hover {{
-                    background-color: {HOVER_BUTTON_COLOR} !important;
-                    color: white !important;
-                }}
-
-                /* Clicked (Active) Effect for ALL Buttons */
-                div.stButton > button:focus,
-                div.stButton > button:active,
-                div.stDownloadButton > button:focus,
-                div.stDownloadButton > button:active {{
-                    background-color: {DEFAULT_BUTTON_COLOR} !important;
-                    color: white !important;
-                    outline: none !important;
-                    border: none !important;
-                }}
-                </style>
+                html, body, [class*="css"] {
+                    font-family: 'Inter', system-ui, 'Segoe UI', Arial, sans-serif;
+                }
+                /* Hide the zero-width place-search submit control; Enter submits */
+                div[data-testid="stForm"]:has(
+                    input[aria-label="Search for a place to add"]
+                ) div[data-testid="stFormSubmitButton"] {
+                    display: none;
+                }
+            </style>
             """,
         unsafe_allow_html=True,
     )


### PR DESCRIPTION
Streamlines the Click 2 Vector UI around compact expanders and tightens map/import behavior for a cleaner default workflow.

- Reorganized the app into collapsed **Advanced options**, **Location table**, and **Export settings** expanders; **Download Vector** stays visible outside export settings
- Improved **Google Sheets import**: respects `#gid=...` tab URLs and shows clearer errors for missing coordinate columns, title rows, and wrong tabs
- Added **pin coloring by any table column** (default: Description), with editable legend labels, color pickers, and an optional on-map category legend
- Expanded then curated **basemap choices** to 12 free Carto and Esri raster layers (no API-key providers); default is **Carto Positron (no labels)**; basemap picker is a dropdown with readable labels
- Fixed map refresh issues where **basemap changes** (especially Carto labeled vs no-labels) and **legend toggling** did not always update the Folium iframe
- Polished search/import layout (two-column Advanced options, gray captions), Enter-to-submit place search, direct row deletion in the data editor, Folium fullscreen control, and removal of legacy point-management buttons / default pin-color picker